### PR TITLE
Make stars smaller on large screens, bigger on small screens

### DIFF
--- a/client/views/post/post.less
+++ b/client/views/post/post.less
@@ -41,7 +41,6 @@
 }
 
 .post-stars {
-  font-size: 1.2rem;
   &:last-of-type {
     margin-right: 0.25rem;
   }
@@ -51,6 +50,7 @@
   .post-stars {
     font-size: 1.5rem;
     display: block;
+    text-align: center;
   }
   .post-link, .author, .comments {
     display: block;

--- a/client/views/stars/stars.html
+++ b/client/views/stars/stars.html
@@ -1,5 +1,3 @@
 <template name="stars">
-  {{#each stars}}
-  <i class="star fa {{type}} star-{{num}}" data-num="{{num}}"></i>
-  {{/each}}
+  {{#each stars}}<i class="star fa {{type}} star-{{num}}" data-num="{{num}}"></i>{{/each}}
 </template>

--- a/client/views/stars/stars.less
+++ b/client/views/stars/stars.less
@@ -1,7 +1,7 @@
 .star {
   margin-top:0.5rem;
   margin-bottom: -0.5rem;
-  padding: .5rem;
+  padding: .25rem;
   &:first-of-type {
     padding-left: 0;
   }


### PR DESCRIPTION
This makes it so that even devices like the iPhone 4 can tap the star ratings.

Various device resolutions appended:

![screen shot 2014-03-14 at 2 15 43 pm](https://f.cloud.github.com/assets/537700/2425974/ffd5cff2-abbd-11e3-9684-f6d525148d77.png)
![screen shot 2014-03-14 at 2 15 22 pm](https://f.cloud.github.com/assets/537700/2425975/ffd8dd78-abbd-11e3-90f4-4b0bb0e07ddf.png)
![screen shot 2014-03-14 at 2 15 33 pm](https://f.cloud.github.com/assets/537700/2425976/ffd95118-abbd-11e3-9387-328d41d91de5.png)
![screen shot 2014-03-14 at 2 16 16 pm](https://f.cloud.github.com/assets/537700/2425977/0006547e-abbe-11e3-8a04-ca689699f988.png)
