### PR TITLE
Fix navbar to top

### DIFF
--- a/client/views/header/header.html
+++ b/client/views/header/header.html
@@ -1,6 +1,6 @@
 <template name="header">
   <div class="header">
-    <nav class="navbar navbar-inverse" role="navigation">
+    <nav class="navbar navbar-fixed-top navbar-inverse" role="navigation">
       <div class="container">
         <div class="navbar-header">
           <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#bs-example-navbar-collapse-9">

--- a/client/views/wrapper/wrapper.less
+++ b/client/views/wrapper/wrapper.less
@@ -1,4 +1,5 @@
 .wrapper {
+  margin-top: 50px;
   &.container {
     padding: 0;
   }


### PR DESCRIPTION
This adds a 50px margin to .wrapper to compensate for the height of the navbar, and makes the navbar stick to the top of the browser when scrolling.
