### PR TITLE
Fix Firefox bug when creating a new post

### DIFF
--- a/client/views/newPost/newPost.js
+++ b/client/views/newPost/newPost.js
@@ -1,5 +1,5 @@
 Template.newPost.events({
-  'submit': function () {
+  'submit': function (event) {
     "use strict";
     event.preventDefault();
     var title = $('form .title').val();


### PR DESCRIPTION
Event wasn't defined, so it's kind of difficult to call preventDefault() on – Chrome doesn't auto-submit the form without an action, but Firefox does.
