### PR TITLE
Make regexp easier to read

### DIFF
--- a/server/newPost/newPost.js
+++ b/server/newPost/newPost.js
@@ -1,7 +1,7 @@
 // Make sure there's no "javascript:alert()" douchebaggery
 var isWebAddress = function (value) {
   "use strict";
-  return /^https?:\/\//i.test(value);
+  return (/^https?:\/\//i).test(value);
 };
 
 Meteor.methods({


### PR DESCRIPTION
The parens don't do anything other than make it easier to read, but CodeClimate wanted me to do it... so I'm doing it.
