### PR TITLE
Move 'use strict' to file scope

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -33,7 +33,7 @@
     "evil"          : false,
     "expr"          : false,
     "funcscope"     : false,
-    "globalstrict"  : false,
+    "globalstrict"  : true,
     "iterator"      : false,
     "lastsemic"     : false,
     "laxbreak"      : false,
@@ -63,5 +63,19 @@
     "nomen"         : false,
     "onevar"        : false,
     "passfail"      : false,
-    "white"         : false
+    "white"         : false,
+    "globals"       : {
+      "Meteor" : false,
+      "AccountsEntry" : false,
+      "Session" : false,
+      "Handlebars" : false,
+      "Template" : false,
+      "$" : false,
+      "Votes" : false,
+      "Router" : false,
+      "Route" : false,
+      "Posts" : false,
+      "_" : false
+      
+    }
 }

--- a/client/config/accounts/accountsConfig.js
+++ b/client/config/accounts/accountsConfig.js
@@ -1,5 +1,6 @@
+'use strict';
+
 Meteor.startup(function () {
-  "use strict";
   AccountsEntry.config({
     privacyUrl:     '/privacy-policy',
     termsUrl:       '/terms-of-use',

--- a/client/layout/layout.js
+++ b/client/layout/layout.js
@@ -1,12 +1,12 @@
+'use strict';
+
 Handlebars.registerHelper('session', function(input) {
-  "use strict";
   return Session.get(input);
 });
 
 var levels = ['success', 'info', 'warning', 'danger'];
 
 var createAlert = function (level) {
-  "use strict";
   Handlebars.registerHelper(level, function(title, msg) {
     var str = '<strong>' + title + '</strong> ' + msg;
     return '<div class="alert alert-' + level + '">' + str + '</div>';

--- a/client/layout/main/main.js
+++ b/client/layout/main/main.js
@@ -1,6 +1,7 @@
+'use strict';
+
 Template.main.helpers({
   'currentView' : function () {
-    "use strict";
     return Session.get('currentView');
   }
 });

--- a/client/layout/sidebar/sidebar.js
+++ b/client/layout/sidebar/sidebar.js
@@ -1,6 +1,6 @@
-Handlebars.registerHelper('activeTime', function(time) {
-  "use strict";
+'use strict';
 
+Handlebars.registerHelper('activeTime', function(time) {
   if (Session.equals('sortTime', time)) {
     return 'active';
   } else {
@@ -9,8 +9,6 @@ Handlebars.registerHelper('activeTime', function(time) {
 });
 
 Handlebars.registerHelper('activeSort', function(sort) {
-  "use strict";
-
   if (Session.equals('sortType', sort)) {
     return 'active';
   } else {
@@ -20,8 +18,6 @@ Handlebars.registerHelper('activeSort', function(sort) {
 
 Template.sidebar.helpers({
   'isSortTop' : function () {
-    "use strict";
-
     if (Session.equals('sortType', 'top')) {
       return true;
     } else {
@@ -29,12 +25,9 @@ Template.sidebar.helpers({
     }
   },
   'sortType' : function () {
-    "use strict";
     return Session.get('sortType');
   },
   'showBack' : function () {
-    "use strict";
-
     // only show a back button on comment/user pages, where sortType is unset
     if (Session.equals('sortType', null)) {
       return true;
@@ -43,7 +36,6 @@ Template.sidebar.helpers({
     }
   },
   'backLink' : function () {
-    "use strict";
     return '/';
   }
 });

--- a/client/posts/comments/viewComment.js
+++ b/client/posts/comments/viewComment.js
@@ -1,7 +1,7 @@
+'use strict';
+
 // adapted from http://stackoverflow.com/a/3177838
 var timeSince = function (date) {
-  "use strict";
-
   var timeString = function (int, str) {
     return int + str;
   };
@@ -33,12 +33,10 @@ var timeSince = function (date) {
 
 Template.viewComment.helpers({
   'cleanText' : function () {
-    "use strict";
     // replace '\n' with a newline character
     return this.text.replace(/\\n/g, "\n");
   },
   'timeCopy' : function () {
-    "use strict";
     /*jshint camelcase: false */
     return timeSince(new Date(this.created_at));
   }

--- a/client/posts/createPost.js
+++ b/client/posts/createPost.js
@@ -1,6 +1,7 @@
+'use strict';
+
 Template.createPost.events({
-  'submit': function (event) {
-    "use strict";
+  'submit': function (event) {    
     event.preventDefault();
     var title = $('form .title').val();
     var url =   $('form .url').val();

--- a/client/posts/viewPost.js
+++ b/client/posts/viewPost.js
@@ -1,7 +1,7 @@
+'use strict';
+
 // adapted from http://stackoverflow.com/a/3177838
 var timeSince = function (date) {
-  "use strict";
-
   var timeString = function (int, str) {
     return int + str;
   };
@@ -33,8 +33,6 @@ var timeSince = function (date) {
 
 Template.viewPost.helpers({
   previousVote: function () {
-    "use strict";
-
     var post = this._id;
     var voteQuery = {
       'user' : Meteor.userId(),
@@ -60,27 +58,21 @@ Template.viewPost.helpers({
     }
   },
   timeCopy: function () {
-    "use strict";
     return timeSince(this.createdAt);
   },
   totalPoints: function () {
-    "use strict";
     return this.oldPoints + Session.get('vote.' + this._id);
   },
   authorLink: function() {
-    "use strict";
     return '/user/' + this.author;
   },
   commentLink: function () {
-    "use strict";
     return '/comments/' + this._id;
   },
   text: function () {
-    "use strict";
     return this.hnText;
   },
   domain: function () {
-    "use strict";
     var d = this.url.replace('http://','');
     d = d.replace('https://','').split(/[/?#]/)[0];
 
@@ -91,13 +83,11 @@ Template.viewPost.helpers({
     return d;
   },
   community: function () {
-    "use strict";
     if (this.site === 'hn') {
       return 'Hacker News';
     }
   },
   communityLink: function () {
-    "use strict";
     if (this.site === 'hn') {
       return 'http://news.ycombinator.com/';
     }

--- a/client/posts/vote/setVote.js
+++ b/client/posts/vote/setVote.js
@@ -1,7 +1,8 @@
+'use strict';
+
 Meteor.subscribe('votes');
 
 var vote = function (event) {
-  "use strict";
   var target = $(event.target);
   var post = target.parent().parent().parent().parent().parent();
 

--- a/server/posts/createPost.js
+++ b/server/posts/createPost.js
@@ -1,13 +1,13 @@
+'use strict';
+
 Meteor.methods({
   createPost : function (obj) {
-    "use strict";
     // disabled
     return obj;
   }
 });
 /*
     var isWebAddress = function (value) {
-      "use strict";
       return (/^https?:\/\//i).test(value);
     };
 

--- a/server/posts/publishPosts.js
+++ b/server/posts/publishPosts.js
@@ -1,5 +1,6 @@
+'use strict';
+
 Meteor.publish('allPosts', function () {
-  "use strict";
   var result = Posts.find({}, {
     limit: 50,
     fields: {
@@ -10,16 +11,12 @@ Meteor.publish('allPosts', function () {
 });
 
 Meteor.publish('comments', function (id) {
-  "use strict";
-
   return Posts.find({
     _id: id
   });
 });
 
 Meteor.publish('user', function (username) {
-  "use strict";
-
   return Posts.find({
     author: username
   },{
@@ -31,7 +28,6 @@ Meteor.publish('user', function (username) {
 });
 
 Meteor.publish('recentPosts', function () {
-  "use strict";
   return Posts.find({}, {
     sort: {
       createdAt: -1
@@ -44,7 +40,6 @@ Meteor.publish('recentPosts', function () {
 });
 
 Meteor.publish('topPosts', function (since) {
-  "use strict";
   return Posts.find({
     oldPoints: {
       $gt: 1
@@ -64,7 +59,6 @@ Meteor.publish('topPosts', function (since) {
 });
 
 Meteor.publish('hotPosts', function () {
-  "use strict";
   return Posts.find({}, {
     limit: 50,
     sort: {

--- a/server/posts/setPostHeat.js
+++ b/server/posts/setPostHeat.js
@@ -1,5 +1,6 @@
+'use strict';
+
 var setPostHeat = function () {
-  "use strict";
   var allArr = Posts.find({
     oldPoints: {
       $gt: 1

--- a/server/read/readHn.js
+++ b/server/read/readHn.js
@@ -1,8 +1,8 @@
+'use strict';
+
 var hn = Meteor.require('hacker-news-api');
 
 var readHn = function (before) {
-  "use strict";
-
   var now = Math.floor(Date.now() / 1000);
   var listQuery = 'search?tags=story&numericFilters=created_at_i>';
   listQuery    += (now - before) + ',created_at_i<' + now;
@@ -50,8 +50,6 @@ var readHn = function (before) {
 };
 
 Meteor.setInterval(function () {         // 4410rph (21 * 7 * (60/2))
-  "use strict";
-
   console.log("Reading 140 posts from Hacker News");
   readHn(2 * 60);                        // 2 minutes - 21 requests
   readHn(60 * 60);                       // hour      - 21 requests

--- a/server/twitter/tweetHot.js
+++ b/server/twitter/tweetHot.js
@@ -1,9 +1,10 @@
+'use strict';
+
 if (Meteor.settings.environment === 'production') {
   var Twit =    Meteor.require('twit');
   var twitter = new Twit(Meteor.settings.twitter);
 
   var tweetHot = function () {
-    "use strict";
     var hot = Posts.find({}, {
       limit: 50,
       sort: {

--- a/server/votes/countVotes.js
+++ b/server/votes/countVotes.js
@@ -1,5 +1,6 @@
+'use strict';
+
 var countVotes = function () {
-  "use strict";
   // find votes for object
   var deltaVotesQuery = {
     delta: {

--- a/server/votes/publishVotes.js
+++ b/server/votes/publishVotes.js
@@ -1,4 +1,5 @@
+'use strict';
+
 Meteor.publish('votes', function () {
-  "use strict";
   return Votes.find({user: this.userId});
 });

--- a/server/votes/setVote.js
+++ b/server/votes/setVote.js
@@ -1,9 +1,9 @@
+'use strict';
+
 Meteor.methods({
   // obj.id = content _id
   // obj.vote = score from -1 to 1
   vote : function (obj) {
-    "use strict";
-
     if (typeof obj !== 'undefined') {
       new Meteor.Error(500, 'Must include object with content ID and vote');
     }

--- a/shared/collections.js
+++ b/shared/collections.js
@@ -1,2 +1,5 @@
+'use strict';
+/*global Posts:true*/
 Posts = new Meteor.Collection('posts');
+/*global Votes:true*/
 Votes = new Meteor.Collection('votes');

--- a/shared/router/config.js
+++ b/shared/router/config.js
@@ -1,4 +1,4 @@
-/*jshint undef:false */
+'use strict';
 
 Router.configure({
   layoutTemplate: 'layout'
@@ -7,16 +7,16 @@ Router.configure({
 Router.onBeforeAction('loading');
 
 Router.map(function () {
-  "use strict";
 
-  this.route('comments', commentsRoute);
-  this.route('hot', hotRoute);
-  this.route('random', randomRoute);
-  this.route('recent', recentRoute);
-  this.route('root', rootRoute);
-  this.route('top', topRoute);
-  this.route('user', userRoute);
+
+  this.route('comments', Route.comments);
+  this.route('hot', Route.hot);
+  this.route('random', Route.random);
+  this.route('recent', Route.recent);
+  this.route('root', Route.root);
+  this.route('top', Route.top);
+  this.route('user', Route.user);
 
   // needs to go last so that it doesn't catch all requests
-  this.route('default', defaultRoute);
+  this.route('default', Route.default);
 });

--- a/shared/router/lib/comments.js
+++ b/shared/router/lib/comments.js
@@ -1,4 +1,4 @@
-commentsRoute = {
+Route.comments = {
   controller: 'PageController',
   path: '/comments/:id',
   template: 'listPosts',

--- a/shared/router/lib/default.js
+++ b/shared/router/lib/default.js
@@ -1,4 +1,4 @@
-defaultRoute = {
+Route.default = {
   path: '*',
   action: function () {
     "use strict";

--- a/shared/router/lib/hot.js
+++ b/shared/router/lib/hot.js
@@ -1,4 +1,4 @@
-hotRoute = {
+Route.hot = {
   controller: 'NewsController',
   path:     '/hot',
   template: 'listPosts',

--- a/shared/router/lib/lib/routes.js
+++ b/shared/router/lib/lib/routes.js
@@ -1,0 +1,2 @@
+/*global Route:true*/
+Route = {};

--- a/shared/router/lib/random.js
+++ b/shared/router/lib/random.js
@@ -1,4 +1,4 @@
-randomRoute = {
+Route.random = {
   controller: 'NewsController',
   path:     '/random',
   template: 'listPosts',

--- a/shared/router/lib/recent.js
+++ b/shared/router/lib/recent.js
@@ -1,4 +1,4 @@
-recentRoute = {
+Route.recent = {
   controller: 'NewsController',
   path:     '/recent',
   template: 'listPosts',
@@ -8,7 +8,7 @@ recentRoute = {
   },
   onAfterAction: function () {
     "use strict";
-    
+
     setNewsSession('recent');
     Session.set('posts', Posts.find({}, {
       reactive: false,

--- a/shared/router/lib/root.js
+++ b/shared/router/lib/root.js
@@ -1,7 +1,9 @@
-rootRoute = {
+'use strict';
+
+
+Route.root = {
   path: '/',
   action: function () {
-    "use strict";
     Router.go('/hot');
   }
 };

--- a/shared/router/lib/top.js
+++ b/shared/router/lib/top.js
@@ -1,4 +1,4 @@
-topRoute = {
+Route.top = {
   controller: 'NewsController',
   path:     '/top/:time',
   template: 'listPosts',

--- a/shared/router/lib/user.js
+++ b/shared/router/lib/user.js
@@ -1,4 +1,4 @@
-userRoute = {
+Route.user = {
   controller: 'NewsController',
   path: '/user/:username',
   template: 'listPosts',


### PR DESCRIPTION
Right now JSHint is throwing errors on the globals being used in the
functions. The workaround for this bug is to throw our globals in the
.jshintrc and set `/*global SomeGlobal:true*/` when defining SomeGlobal
but I opened jshint/jshint#1665 to deal with this bug.
